### PR TITLE
Remove debugging echos from get_field_width()

### DIFF
--- a/partition-info
+++ b/partition-info
@@ -387,11 +387,7 @@ get_field_width() {
                 hfsplus) field=HPFS  ;;
             esac
         fi
-
-        echo $field >&2
-
         fwidth=${#field}
-        #echo "$dwidth: $dev" >&2
         [ $width -lt $fwidth ] && width=$fwidth
     done<<Get_Field_Width
 $(lsblk --output $name --list $*)


### PR DESCRIPTION
This was causing many extra lines to be printed before the list
